### PR TITLE
Feature/allow parallel writes

### DIFF
--- a/Source/Characteristic/BLECharacteristic.swift
+++ b/Source/Characteristic/BLECharacteristic.swift
@@ -30,4 +30,11 @@ public struct BLECharacteristic: BLEPeripheralResult {
     public func setNotifyValue(_ enabled: Bool) {
         peripheral.setNotifyValue(enabled, for: value)
     }
+    
+    public func writeValue(
+        _ data: Data,
+        type: CBCharacteristicWriteType
+    ) -> AnyPublisher<Never, BLEError> {
+        return peripheral.writeValue(data, for: self.value, type: type)
+    }
 }

--- a/Source/Peripheral/BLEPeripheral.swift
+++ b/Source/Peripheral/BLEPeripheral.swift
@@ -22,7 +22,7 @@ public protocol BLEPeripheral {
     func observeValue(for characteristic: CBCharacteristic) -> AnyPublisher<BLEData, BLEError>
     func observeValueUpdateAndSetNotification(for characteristic: CBCharacteristic) -> AnyPublisher<BLEData, BLEError>
     func setNotifyValue(_ enabled: Bool, for characteristic: CBCharacteristic)
-    func writeValue(_ data: Data, for characteristic: CBCharacteristic, type: CBCharacteristicWriteType) -> AnyPublisher<Bool, BLEError>
+    func writeValue(_ data: Data, for characteristic: CBCharacteristic, type: CBCharacteristicWriteType) -> AnyPublisher<Never, BLEError>
 }
 
 protocol BLEPeripheralState {

--- a/Source/Peripheral/StandardBLEPeripheral.swift
+++ b/Source/Peripheral/StandardBLEPeripheral.swift
@@ -198,6 +198,12 @@ final public class StandardBLEPeripheral: BLEPeripheral, BLEPeripheralState {
             return self.delegate
                 .didWriteValueForCharacteristic
                 .filter({ $0.characteristic == characteristic })
+                .tryMap({ result -> CBCharacteristic in
+                    if let error = result.error {
+                        throw error
+                    }
+                    return result.characteristic
+                })
                 .mapError({ BLEError.writeFailed($0) })
                 .first()
                 .ignoreOutput()

--- a/Source/Peripheral/StandardBLEPeripheral.swift
+++ b/Source/Peripheral/StandardBLEPeripheral.swift
@@ -189,7 +189,9 @@ final public class StandardBLEPeripheral: BLEPeripheral, BLEPeripheralState {
         for characteristic: CBCharacteristic,
         type: CBCharacteristicWriteType
     ) -> AnyPublisher<Never, BLEError> {
-        peripheral.writeValue(data, for: characteristic, type: type)
+        defer {
+            peripheral.writeValue(data, for: characteristic, type: type)
+        }
         
         switch type {
         case .withResponse:
@@ -197,6 +199,7 @@ final public class StandardBLEPeripheral: BLEPeripheral, BLEPeripheralState {
                 .didWriteValueForCharacteristic
                 .filter({ $0.characteristic == characteristic })
                 .mapError({ BLEError.writeFailed($0) })
+                .first()
                 .ignoreOutput()
                 .eraseToAnyPublisher()
         default:

--- a/Source/Peripheral/StandardBLEPeripheral.swift
+++ b/Source/Peripheral/StandardBLEPeripheral.swift
@@ -18,7 +18,6 @@ final public class StandardBLEPeripheral: BLEPeripheral, BLEPeripheralState {
     private var connectCancellable: AnyCancellable?
     private var discoverServicesCancellable: AnyCancellable?
     private var discoverCharacteristicsCancellable: AnyCancellable?
-    private var writeValueCancellable: AnyCancellable?
     
     init(
         peripheral: CBPeripheralWrapper,
@@ -189,30 +188,21 @@ final public class StandardBLEPeripheral: BLEPeripheral, BLEPeripheralState {
         _ data: Data,
         for characteristic: CBCharacteristic,
         type: CBCharacteristicWriteType
-    ) -> AnyPublisher<Bool, BLEError> {
+    ) -> AnyPublisher<Never, BLEError> {
         peripheral.writeValue(data, for: characteristic, type: type)
-        writeValueCancellable?.cancel()
         
         switch type {
         case .withResponse:
-            return Future<Bool, BLEError> { [weak self] promise in
-                guard let self = self else { return }
-                self.writeValueCancellable = self.delegate
-                    .didWriteValueForCharacteristic
-                    .tryMap { result -> Bool in
-                        if let error = result.error { throw BLEError.writeFailed(error) }
-                        return result.characteristic == characteristic
-                    }
-                    .mapError { $0 as? BLEError ?? BLEError.unknown }
-                    .sink(receiveCompletion: { completion in
-                        guard case .failure(let error) = completion else { return }
-                        promise(.failure(error))
-                    }, receiveValue: { value in
-                        promise(.success(value))
-                    })
-            }.eraseToAnyPublisher()
+            return self.delegate
+                .didWriteValueForCharacteristic
+                .filter({ $0.characteristic == characteristic })
+                .mapError({ BLEError.writeFailed($0) })
+                .ignoreOutput()
+                .eraseToAnyPublisher()
         default:
-            return Just.init(true).setFailureType(to: BLEError.self).eraseToAnyPublisher()
+            return Empty(completeImmediately: true)
+                .setFailureType(to: BLEError.self)
+                .eraseToAnyPublisher()
         }
     }
     

--- a/Tests/BLECharacteristicTests.swift
+++ b/Tests/BLECharacteristicTests.swift
@@ -48,5 +48,14 @@ class BLECharacteristicTests: XCTestCase {
         
         XCTAssertTrue(blePeripheralMock.setNotifyValueWasCalled)
     }
+    
+    func testWriteValue() {
+        let cbCharacteristic = CBMutableCharacteristic(type: CBUUID.init(string: "0x0000"), properties: CBCharacteristicProperties.init(), value: Data(), permissions: CBAttributePermissions.init())
+        let sut = BLECharacteristic(value: cbCharacteristic, peripheral: blePeripheralMock)
+        
+        _ = sut.writeValue(Data(), type: .withResponse)
+        
+        XCTAssertTrue(blePeripheralMock.writeValueWasCalled)
+    }
 
 }

--- a/Tests/BLEPeripheralTests.swift
+++ b/Tests/BLEPeripheralTests.swift
@@ -269,8 +269,10 @@ class BLEPeripheralTests: XCTestCase {
         
         // When
         sut.writeValue(Data(), for: mutableCharacteristic, type: .withResponse)
-            .sink(receiveCompletion: { error in
-                expectation.fulfill()
+            .sink(receiveCompletion: { completion in
+                if case .failure(let error) = completion, case .writeFailed(let error) = error, let error = error as? BLEError, case .unknown = error {
+                    expectation.fulfill()
+                }
             }, receiveValue: { _ in
             })
             .store(in: &disposable)

--- a/Tests/BLEPeripheralTests.swift
+++ b/Tests/BLEPeripheralTests.swift
@@ -230,7 +230,6 @@ class BLEPeripheralTests: XCTestCase {
     func testWriteValueWithoutResponseReturnsImmediately() {
         // Given
         let expectation = XCTestExpectation(description: #function)
-        var expectedResult: Bool?
         let mutableCharacteristic = CBMutableCharacteristic(type: CBUUID.init(string: "0x0000"), properties: CBCharacteristicProperties.init(), value: Data(), permissions: CBAttributePermissions.init())
         
         // When
@@ -238,19 +237,16 @@ class BLEPeripheralTests: XCTestCase {
             .sink(receiveCompletion: { event in
                 expectation.fulfill()
             }, receiveValue: { result in
-                expectedResult = result
             }).store(in: &disposable)
         
         // Then
         wait(for: [expectation], timeout: 0.005)
         XCTAssertTrue(peripheralMock.writeValueForCharacteristicWasCalled)
-        XCTAssertNotNil(expectedResult)
     }
     
     func testWriteValueWithResponseReturnsOnDelegateCall() {
         // Given
         let expectation = XCTestExpectation(description: #function)
-        var expectedResult: Bool?
         let mutableCharacteristic = CBMutableCharacteristic(type: CBUUID.init(string: "0x0000"), properties: CBCharacteristicProperties.init(), value: Data(), permissions: CBAttributePermissions.init())
         
         // When
@@ -258,13 +254,11 @@ class BLEPeripheralTests: XCTestCase {
             .sink(receiveCompletion: { error in
                 expectation.fulfill()
             }, receiveValue: { result in
-                expectedResult = result
             }).store(in: &disposable)
         delegate.didWriteValueForCharacteristic.send((peripheral: peripheralMock, characteristic: mutableCharacteristic, error: nil))
         
         // Then
         wait(for: [expectation], timeout: 0.005)
-        XCTAssertNotNil(expectedResult)
         XCTAssertTrue(peripheralMock.writeValueForCharacteristicWasCalled)
     }
     
@@ -278,7 +272,6 @@ class BLEPeripheralTests: XCTestCase {
             .sink(receiveCompletion: { error in
                 expectation.fulfill()
             }, receiveValue: { _ in
-                XCTFail()
             })
             .store(in: &disposable)
         delegate.didWriteValueForCharacteristic.send((peripheral: peripheralMock, characteristic: mutableCharacteristic, error: BLEError.unknown))

--- a/Tests/Mocks/BLEPeripheralMocks.swift
+++ b/Tests/Mocks/BLEPeripheralMocks.swift
@@ -91,9 +91,9 @@ final class MockBLEPeripheral: BLEPeripheral, BLEPeripheralState {
     }
     
     var writeValueWasCalled = false
-    func writeValue(_ data: Data, for characteristic: CBCharacteristic, type: CBCharacteristicWriteType) -> AnyPublisher<Bool, BLEError> {
+    func writeValue(_ data: Data, for characteristic: CBCharacteristic, type: CBCharacteristicWriteType) -> AnyPublisher<Never, BLEError> {
         writeValueWasCalled = true
-        return Just.init(true).setFailureType(to: BLEError.self).eraseToAnyPublisher()
+        return Empty(completeImmediately: true).setFailureType(to: BLEError.self).eraseToAnyPublisher()
     }
     
 }


### PR DESCRIPTION
I'm not sure if there was a reason that the original implementation didn't allow multiple writes, as CoreBluetooth can handle that, so I removed that restriction. I also added a convenience method to `BLECharacteristic` to perform a write as that is where users may expect it (I did!)