### PR TITLE
Peripheral mode support - `CBPeripheralManager` Combine extensions.

### DIFF
--- a/BLECombineKit.xcodeproj/project.pbxproj
+++ b/BLECombineKit.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -52,6 +52,10 @@
 		39E7B702245ED60B0065044C /* DevicesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E7B701245ED60B0065044C /* DevicesView.swift */; };
 		39E7B705245ED6840065044C /* ActionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E7B704245ED6840065044C /* ActionState.swift */; };
 		39E7B708245EDA320065044C /* BLECombineKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E7B707245EDA320065044C /* BLECombineKit.swift */; };
+		48059532269C8C51001FD18D /* BLEPeripheralManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48059531269C8C51001FD18D /* BLEPeripheralManager.swift */; };
+		48059536269C8ECA001FD18D /* BLEPeripheralManagerDelegateWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48059535269C8ECA001FD18D /* BLEPeripheralManagerDelegateWrapper.swift */; };
+		4805953A269C9986001FD18D /* StartAdvertisingResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48059539269C9986001FD18D /* StartAdvertisingResult.swift */; };
+		48059553269CA046001FD18D /* CombineExt in Frameworks */ = {isa = PBXBuildFile; productRef = 48059552269CA046001FD18D /* CombineExt */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -138,6 +142,9 @@
 		39E7B701245ED60B0065044C /* DevicesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevicesView.swift; sourceTree = "<group>"; };
 		39E7B704245ED6840065044C /* ActionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionState.swift; sourceTree = "<group>"; };
 		39E7B707245EDA320065044C /* BLECombineKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BLECombineKit.swift; sourceTree = "<group>"; };
+		48059531269C8C51001FD18D /* BLEPeripheralManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BLEPeripheralManager.swift; sourceTree = "<group>"; };
+		48059535269C8ECA001FD18D /* BLEPeripheralManagerDelegateWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BLEPeripheralManagerDelegateWrapper.swift; sourceTree = "<group>"; };
+		48059539269C9986001FD18D /* StartAdvertisingResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartAdvertisingResult.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -145,6 +152,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				48059553269CA046001FD18D /* CombineExt in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -201,6 +209,7 @@
 				39AC63E0245D12260024D677 /* Characteristic */,
 				39AC63DF245D07D60024D677 /* Central */,
 				39AC63DE245D07C80024D677 /* Peripheral */,
+				48059530269C8AB3001FD18D /* Peripheral Manager */,
 				39AC63C7245D07A70024D677 /* BLECombineKit.h */,
 				39AC63C8245D07A70024D677 /* Info.plist */,
 			);
@@ -385,6 +394,16 @@
 			path = Main;
 			sourceTree = "<group>";
 		};
+		48059530269C8AB3001FD18D /* Peripheral Manager */ = {
+			isa = PBXGroup;
+			children = (
+				48059531269C8C51001FD18D /* BLEPeripheralManager.swift */,
+				48059535269C8ECA001FD18D /* BLEPeripheralManagerDelegateWrapper.swift */,
+				48059539269C9986001FD18D /* StartAdvertisingResult.swift */,
+			);
+			path = "Peripheral Manager";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -412,6 +431,9 @@
 			dependencies = (
 			);
 			name = BLECombineKit;
+			packageProductDependencies = (
+				48059552269CA046001FD18D /* CombineExt */,
+			);
 			productName = BLECombineKit;
 			productReference = 39AC63C4245D07A70024D677 /* BLECombineKit.framework */;
 			productType = "com.apple.product-type.framework";
@@ -484,6 +506,9 @@
 				Base,
 			);
 			mainGroup = 39AC63BA245D07A70024D677;
+			packageReferences = (
+				48059551269CA046001FD18D /* XCRemoteSwiftPackageReference "CombineExt" */,
+			);
 			productRefGroup = 39AC63C5245D07A70024D677 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -527,7 +552,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4805953A269C9986001FD18D /* StartAdvertisingResult.swift in Sources */,
 				39AC63F7245D12DE0024D677 /* BLECharacteristic.swift in Sources */,
+				48059536269C8ECA001FD18D /* BLEPeripheralManagerDelegateWrapper.swift in Sources */,
 				39AC63EF245D12B40024D677 /* CBPeripheralWrapper.swift in Sources */,
 				39AC63F4245D12D00024D677 /* ManagerState.swift in Sources */,
 				39BE8C92245D5E54004F73DD /* BLEScanResult.swift in Sources */,
@@ -542,6 +569,7 @@
 				39AC63F5245D12D00024D677 /* BLECentralManagerDelegate.swift in Sources */,
 				39E7B708245EDA320065044C /* BLECombineKit.swift in Sources */,
 				39AC63EB245D12A90024D677 /* BLEPeripheral.swift in Sources */,
+				48059532269C8C51001FD18D /* BLEPeripheralManager.swift in Sources */,
 				39BE8C1B245D23A1004F73DD /* CBCentralManagerWrapper.swift in Sources */,
 				39AC63E4245D12890024D677 /* BLEData.swift in Sources */,
 			);
@@ -907,6 +935,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		48059551269CA046001FD18D /* XCRemoteSwiftPackageReference "CombineExt" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/CombineCommunity/CombineExt.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.3.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		48059552269CA046001FD18D /* CombineExt */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 48059551269CA046001FD18D /* XCRemoteSwiftPackageReference "CombineExt" */;
+			productName = CombineExt;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 39AC63BB245D07A70024D677 /* Project object */;
 }

--- a/BLECombineKit.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/BLECombineKit.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:BLECombineKit.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/BLECombineKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BLECombineKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,34 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "combine-schedulers",
+        "repositoryURL": "https://github.com/pointfreeco/combine-schedulers",
+        "state": {
+          "branch": null,
+          "revision": "c37e5ae8012fb654af776cc556ff8ae64398c841",
+          "version": "0.5.0"
+        }
+      },
+      {
+        "package": "CombineExt",
+        "repositoryURL": "https://github.com/CombineCommunity/CombineExt.git",
+        "state": {
+          "branch": null,
+          "revision": "5b8a0c0f178527f9204200505c5fefa6847e528f",
+          "version": "1.3.0"
+        }
+      },
+      {
+        "package": "xctest-dynamic-overlay",
+        "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
+        "state": {
+          "branch": null,
+          "revision": "603974e3909ad4b48ba04aad7e0ceee4f077a518",
+          "version": "0.1.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -11,11 +11,16 @@ let package = Package(
     products: [
         .library(name: "BLECombineKit", targets: ["BLECombineKit"])
     ],
-    dependencies: [],
+    dependencies: [
+        .package(
+            url: "https://github.com/CombineCommunity/CombineExt.git",
+            from: "1.0.0"
+        )
+    ],
     targets: [
         .target(
                 name: "BLECombineKit",
-                dependencies: [],
+                dependencies: ["CombineExt"],
                 path: ".",
                 exclude: [
                     "Source/BLECombineKit.h",

--- a/Source/Error/BLEError.swift
+++ b/Source/Error/BLEError.swift
@@ -31,6 +31,15 @@ public enum BLEError: Error {
     case servicesFoundError(Error?)
     case characteristicsFoundError(Error?)
     
+    // Advertising
+    case advertisingInProgress
+    case advertisingStartFailed(Error?)
+    case addingServiceFailed(CBService, Error?)
+    
+    // L2CAP
+    case openingL2CAPChannelFailed(BLEPeripheral, Error?)
+    case publishingL2CAPChannelFailed(CBL2CAPPSM, Error?)
+    
     // Data
     case invalidData
     case dataConversionFailed

--- a/Source/Peripheral Manager/BLEPeripheralManager.swift
+++ b/Source/Peripheral Manager/BLEPeripheralManager.swift
@@ -410,6 +410,11 @@ public class BLEPeripheralManager {
 private extension Publisher {
     
     func ensure(_ state: ManagerState, manager: BLEPeripheralManager) -> AnyPublisher<Self.Output, Self.Failure> {
-        self.prefix(untilOutputFrom: manager.observeStateWithInitialValue().filter { $0 != state }).eraseToAnyPublisher()
+        Deferred {
+            self.prefix(
+                untilOutputFrom: manager.observeStateWithInitialValue().filter { $0 != state }
+            )
+        }
+        .eraseToAnyPublisher()
     }
 }

--- a/Source/Peripheral Manager/BLEPeripheralManager.swift
+++ b/Source/Peripheral Manager/BLEPeripheralManager.swift
@@ -1,0 +1,408 @@
+//
+//  BLEPeripheralManager.swift
+//  BLECombineKit
+//
+//  Created by Przemyslaw Stasiak on 12/07/2021.
+//  Copyright © 2021 Henry Serrano. All rights reserved.
+//
+
+import Foundation
+import CoreBluetooth
+import Combine
+import CombineExt
+
+/// BLEPeripheralManager is a class implementing ReactiveX API which wraps all the Core Bluetooth Peripheral's functions, that allow to
+/// advertise, to publish L2CAP channels and more.
+/// You can start using this class by adding services and starting advertising.
+/// Before calling any public `BLEPeripheralManager`'s functions you should make sure that Bluetooth is turned on and powered on. It can be done
+/// by `observeStateWithInitialValue()`, observing it's value and then chaining it with `add(_:)` and `startAdvertising(_:)`:
+/// ```
+/// let disposable = peripheralManager.observeStateWithInitialValue()
+///     .filter { $0 == .poweredOn }
+///     .take(1)
+///     .flatMap { peripheralManager.add(myService) }
+///     .flatMap { peripheralManager.startAdvertising(myAdvertisementData) }
+/// ```
+/// As a result, your peripheral will start advertising. To stop advertising simply cancel it:
+/// ```
+/// cancellable.cancel()
+/// ```
+public class BLEPeripheralManager {
+
+    /// Implementation of CBPeripheralManager
+    public let manager: CBPeripheralManager
+
+    let delegateWrapper: BLEPeripheralManagerDelegateWrapper
+
+    /// Lock for checking advertising state
+    private let advertisingLock = NSLock()
+    /// Is there ongoing advertising
+    var isAdvertisingOngoing = false
+    var restoredAdvertisementData: RestoredAdvertisementData?
+
+    // MARK: Initialization
+
+    /// Creates new `PeripheralManager`
+    /// - parameter peripheralManager: `CBPeripheralManager` instance which is used to perform all of the necessary operations
+    /// - parameter delegateWrapper: Wrapper on CoreBluetooth's peripheral manager callbacks.
+    init(peripheralManager: CBPeripheralManager, delegateWrapper: BLEPeripheralManagerDelegateWrapper) {
+        self.manager = peripheralManager
+        self.delegateWrapper = delegateWrapper
+        peripheralManager.delegate = delegateWrapper
+    }
+
+    /// Creates new `PeripheralManager` instance. By default all operations and events are executed and received on main thread.
+    /// - warning: If you pass background queue to the method make sure to observe results on main thread for UI related code.
+    /// - parameter queue: Queue on which bluetooth callbacks are received. By default main thread is used.
+    /// - parameter options: An optional dictionary containing initialization options for a peripheral manager.
+    /// For more info about it please refer to [Peripheral Manager initialization options](https://developer.apple.com/documentation/corebluetooth/cbperipheralmanager/peripheral_manager_initialization_options)
+    /// - parameter cbPeripheralManager: Optional instance of `CBPeripheralManager` to be used as a `manager`. If you
+    /// skip this parameter, there will be created an instance of `CBPeripheralManager` using given queue and options.
+    public convenience init(queue: DispatchQueue = .main,
+                            options: [String: AnyObject]? = nil,
+                            cbPeripheralManager: CBPeripheralManager? = nil) {
+        let delegateWrapper = BLEPeripheralManagerDelegateWrapper()
+        #if os(iOS) || os(macOS)
+        let peripheralManager = cbPeripheralManager ??
+            CBPeripheralManager(delegate: delegateWrapper, queue: queue, options: options)
+        #else
+        let peripheralManager = CBPeripheralManager()
+        peripheralManager.delegate = delegateWrapper
+        #endif
+        self.init(peripheralManager: peripheralManager, delegateWrapper: delegateWrapper)
+    }
+
+    /// Returns the app’s authorization status for sharing data while in the background state.
+    /// Wrapper of `CBPeripheralManager.authorizationStatus()` method.
+    static var authorizationStatus: CBPeripheralManagerAuthorizationStatus {
+        return CBPeripheralManager.authorizationStatus()
+    }
+
+    // MARK: State
+
+    public var state: ManagerState {
+        return ManagerState(rawValue: manager.state.rawValue) ?? .unknown
+    }
+
+    public func observeState() -> AnyPublisher<ManagerState, Never> {
+        return self.delegateWrapper.didUpdateState.eraseToAnyPublisher()
+    }
+
+    public func observeStateWithInitialValue() -> AnyPublisher<ManagerState, Never> {
+        return Deferred<AnyPublisher<ManagerState, Never>> { [weak self] in
+            guard let self = self else {
+                return Empty().eraseToAnyPublisher()
+            }
+
+            return self.delegateWrapper.didUpdateState
+                .eraseToAnyPublisher()
+                .prepend(self.state)
+                .eraseToAnyPublisher()
+        }
+        .eraseToAnyPublisher()
+    }
+
+    // MARK: Advertising
+
+    /// Starts peripheral advertising on subscription. It create inifinite publisher
+    /// which emits only one next value, of enum type `StartAdvertisingResult`, just
+    /// after advertising start succeeds.
+    /// For more info of what specific `StartAdvertisingResult` enum cases means please
+    /// refer to ``StartAdvertisingResult` documentation.
+    ///
+    /// There can be only one ongoing advertising (CoreBluetooth limit).
+    /// It will return `advertisingInProgress` error if this method is called when
+    /// it is already advertising.
+    ///
+    /// Advertising is automatically stopped just after disposing of the subscription.
+    ///
+    /// It can return `BLEError.advertisingStartFailed` error, when start advertisement failed
+    ///
+    /// - parameter advertisementData: Services of peripherals to search for. Nil value will accept all peripherals.
+    /// - returns: Infinite observable which emit `StartAdvertisingResult` when advertisement started.
+    ///
+    /// Publisher can ends with following errors:
+    /// * `BLEError.advertisingInProgress`
+    /// * `BLEError.advertisingStartFailed`
+    /// * `BLEError.deallocated`
+    /// * `BLEError.bluetoothUnsupported`
+    /// * `BLEError.bluetoothUnauthorized`
+    /// * `BLEError.bluetoothPoweredOff`
+    /// * `BLEError.bluetoothInUnknownState`
+    /// * `BLEError.bluetoothResetting`
+    public func startAdvertising(_ advertisementData: [String: Any]?) -> AnyPublisher<StartAdvertisingResult, BLEError> {
+        let publisher: AnyPublisher<StartAdvertisingResult, BLEError> = AnyPublisher.create { [weak self] observer in
+            guard let strongSelf = self else {
+                observer.send(completion: .failure(BLEError.deallocated))
+                return AnyCancellable {}
+            }
+            strongSelf.advertisingLock.lock(); defer { strongSelf.advertisingLock.unlock() }
+            if strongSelf.isAdvertisingOngoing {
+                observer.send(completion: .failure(BLEError.advertisingInProgress))
+                return AnyCancellable {}
+            }
+
+            strongSelf.isAdvertisingOngoing = true
+
+            var cancelable: Cancellable?
+            if strongSelf.manager.isAdvertising {
+                observer.send(.attachedToExternalAdvertising(strongSelf.restoredAdvertisementData))
+                strongSelf.restoredAdvertisementData = nil
+            } else {
+                cancelable = strongSelf.delegateWrapper.didStartAdvertising
+                    .prefix(1)
+                    .tryMap { error throws -> StartAdvertisingResult in
+                        if let error = error {
+                            throw BLEError.advertisingStartFailed(error)
+                        }
+                        return StartAdvertisingResult.started
+                    }
+                    .mapError { $0 as! BLEError }
+                    .sink(receiveCompletion: { observer.send(completion: $0) }, receiveValue: { observer.send($0) })
+                strongSelf.manager.startAdvertising(advertisementData)
+            }
+            return AnyCancellable { [weak self] in
+                guard let strongSelf = self else { return }
+                cancelable?.cancel()
+                strongSelf.manager.stopAdvertising()
+                do { strongSelf.advertisingLock.lock(); defer { strongSelf.advertisingLock.unlock() }
+                    strongSelf.isAdvertisingOngoing = false
+                }
+            }
+        }
+
+        return publisher.ensure(.poweredOn, manager: self)
+    }
+
+    // MARK: Services
+
+    /// Function that triggers `CBPeripheralManager.add(_:)` and waits for
+    /// delegate `CBPeripheralManagerDelegate.peripheralManager(_:didAdd:error:)` result.
+    /// If it receives a non nil in the result, it will emit `BLEError.addingServiceFailed` error.
+    /// Add method is called after subscription to `Observable` is made.
+    /// - Parameter service: `Characteristic` to read value from
+    /// - Returns: `Single` which emits `next` with given characteristic when value is ready to read.
+    ///
+    /// Observable can ends with following errors:
+    /// * `BLEError.addingServiceFailed`
+    /// * `BLEError.deallocated`
+    /// * `BLEError.bluetoothUnsupported`
+    /// * `BLEError.bluetoothUnauthorized`
+    /// * `BLEError.bluetoothPoweredOff`
+    /// * `BLEError.bluetoothInUnknownState`
+    /// * `BLEError.bluetoothResetting`
+    public func add(_ service: CBMutableService) -> AnyPublisher<CBService, BLEError> {
+        let observable = delegateWrapper
+            .didAddService
+            .filter { $0.0.uuid == service.uuid }
+            .prefix(1)
+            .tryMap { (cbService, error) throws -> CBService in
+                if let error = error {
+                    throw error
+                }
+                return cbService
+            }
+            .mapError { BLEError.addingServiceFailed(service, $0) }
+            .eraseToAnyPublisher()
+        return ensureValidStateAndCallIfSucceeded(for: observable) {
+            [weak self] in
+            self?.manager.add(service)
+        }
+    }
+
+    /// Wrapper for `CBPeripheralManager.remove(_:)` method
+    public func remove(_ service: CBMutableService) {
+        manager.remove(service)
+    }
+
+    /// Wrapper for `CBPeripheralManager.removeAllServices()` method
+    public func removeAllServices() {
+        manager.removeAllServices()
+    }
+
+    // MARK: Read & Write
+
+    /// Continuous observer for `CBPeripheralManagerDelegate.peripheralManager(_:didReceiveRead:)` results
+    /// - returns: Observable that emits `next` event whenever didReceiveRead occurs.
+    ///
+    /// It's **infinite** stream, so `.complete` is never called.
+    ///
+    /// Observable can ends with following errors:
+    /// * `BLEError.deallocated`
+    /// * `BLEError.bluetoothUnsupported`
+    /// * `BLEError.bluetoothUnauthorized`
+    /// * `BLEError.bluetoothPoweredOff`
+    /// * `BLEError.bluetoothInUnknownState`
+    /// * `BLEError.bluetoothResetting`
+    public func observeDidReceiveRead() -> AnyPublisher<CBATTRequest, Never> {
+        delegateWrapper.didReceiveRead.ensure(.poweredOn, manager: self)
+    }
+
+    /// Continuous observer for `CBPeripheralManagerDelegate.peripheralManager(_:didReceiveWrite:)` results
+    /// - returns: Observable that emits `next` event whenever didReceiveWrite occurs.
+    ///
+    /// It's **infinite** stream, so `.complete` is never called.
+    ///
+    /// Observable can ends with following errors:
+    /// * `BLEError.deallocated`
+    /// * `BLEError.bluetoothUnsupported`
+    /// * `BLEError.bluetoothUnauthorized`
+    /// * `BLEError.bluetoothPoweredOff`
+    /// * `BLEError.bluetoothInUnknownState`
+    /// * `BLEError.bluetoothResetting`
+    public func observeDidReceiveWrite() -> AnyPublisher<[CBATTRequest], Never> {
+        delegateWrapper.didReceiveWrite.ensure(.poweredOn, manager: self)
+    }
+
+    /// Wrapper for `CBPeripheralManager.respond(to:withResult:)` method
+    public func respond(to request: CBATTRequest, withResult result: CBATTError.Code) {
+        manager.respond(to: request, withResult: result)
+    }
+
+    // MARK: Updating value
+
+    /// Wrapper for `CBPeripheralManager.updateValue(_:for:onSubscribedCentrals:)` method
+    public func updateValue(
+        _ value: Data,
+        for characteristic: CBMutableCharacteristic,
+        onSubscribedCentrals centrals: [CBCentral]?) -> Bool {
+        return manager.updateValue(value, for: characteristic, onSubscribedCentrals: centrals)
+    }
+
+    /// Continuous observer for `CBPeripheralManagerDelegate.peripheralManagerIsReady(toUpdateSubscribers:)` results
+    /// - returns: Observable that emits `next` event whenever isReadyToUpdateSubscribers occurs.
+    ///
+    /// It's **infinite** stream, so `.complete` is never called.
+    ///
+    /// Observable can ends with following errors:
+    /// * `BLEError.deallocated`
+    /// * `BLEError.bluetoothUnsupported`
+    /// * `BLEError.bluetoothUnauthorized`
+    /// * `BLEError.bluetoothPoweredOff`
+    /// * `BLEError.bluetoothInUnknownState`
+    /// * `BLEError.bluetoothResetting`
+    public func observeIsReadyToUpdateSubscribers() -> AnyPublisher<Void, Never> {
+        delegateWrapper.isReady.ensure(.poweredOn, manager: self)
+    }
+
+    // MARK: Subscribing
+
+    /// Continuous observer for `CBPeripheralManagerDelegate.peripheralManager(_:central:didSubscribeTo:)` results
+    /// - returns: Observable that emits `next` event whenever didSubscribeTo occurs.
+    ///
+    /// It's **infinite** stream, so `.complete` is never called.
+    ///
+    /// Observable can ends with following errors:
+    /// * `BLEError.deallocated`
+    /// * `BLEError.bluetoothUnsupported`
+    /// * `BLEError.bluetoothUnauthorized`
+    /// * `BLEError.bluetoothPoweredOff`
+    /// * `BLEError.bluetoothInUnknownState`
+    /// * `BLEError.bluetoothResetting`
+    public func observeOnSubscribe() -> AnyPublisher<(CBCentral, CBCharacteristic), Never> {
+        delegateWrapper.didSubscribeTo.ensure(.poweredOn, manager: self)
+    }
+
+    /// Continuous observer for `CBPeripheralManagerDelegate.peripheralManager(_:central:didUnsubscribeFrom:)` results
+    /// - returns: Observable that emits `next` event whenever didUnsubscribeFrom occurs.
+    ///
+    /// It's **infinite** stream, so `.complete` is never called.
+    ///
+    /// Observable can ends with following errors:
+    /// * `BLEError.deallocated`
+    /// * `BLEError.bluetoothUnsupported`
+    /// * `BLEError.bluetoothUnauthorized`
+    /// * `BLEError.bluetoothPoweredOff`
+    /// * `BLEError.bluetoothInUnknownState`
+    /// * `BLEError.bluetoothResetting`
+    public func observeOnUnsubscribe() -> AnyPublisher<(CBCentral, CBCharacteristic), Never> {
+        delegateWrapper.didUnsubscribeFrom.ensure(.poweredOn, manager: self)
+    }
+
+    // MARK: L2CAP
+
+    #if os(iOS) || os(tvOS) || os(watchOS)
+
+    /// Starts publishing L2CAP channel on a subscription. It creates an infinite observable
+    /// which emits only one next value, of `CBL2CAPPSM` type, just
+    /// after L2CAP channel has been published.
+    ///
+    /// Channel is automatically unpublished just after disposing of the subscription.
+    ///
+    /// It can return `publishingL2CAPChannelFailed` error when publishing channel failed
+    ///
+    /// - parameter encryptionRequired: Publishing channel with or without encryption.
+    /// - returns: Infinite observable which emit `CBL2CAPPSM` when channel published.
+    ///
+    /// Observable can ends with following errors:
+    /// * `BLEError.publishingL2CAPChannelFailed`
+    /// * `BLEError.deallocated`
+    /// * `BLEError.bluetoothUnsupported`
+    /// * `BLEError.bluetoothUnauthorized`
+    /// * `BLEError.bluetoothPoweredOff`
+    /// * `BLEError.bluetoothInUnknownState`
+    /// * `BLEError.bluetoothResetting`
+    @available(iOS 11, tvOS 11, watchOS 4, *)
+    public func publishL2CAPChannel(withEncryption encryptionRequired: Bool) -> AnyPublisher<CBL2CAPPSM, BLEError> {
+        let observable: AnyPublisher<CBL2CAPPSM, BLEError> = .create { [weak self] observer in
+            guard let strongSelf = self else {
+                observer.send(completion: .failure(.deallocated))
+                return AnyCancellable {}
+            }
+
+            var result: CBL2CAPPSM?
+            let cancellable = strongSelf.delegateWrapper.didPublishL2CAPChannel
+                .prefix(1)
+                .tryMap { (cbl2cappSm, error) throws -> (CBL2CAPPSM) in
+                    if let error = error {
+                        throw BLEError.publishingL2CAPChannelFailed(cbl2cappSm, error)
+                    }
+                    result = cbl2cappSm
+                    return cbl2cappSm
+                }
+                .mapError { $0 as! BLEError }
+                .sink(receiveCompletion: { observer.send(completion: $0) }, receiveValue: { observer.send($0) })
+            strongSelf.manager.publishL2CAPChannel(withEncryption: encryptionRequired)
+            return AnyCancellable { [weak self] in
+                guard let strongSelf = self else { return }
+                cancellable.cancel()
+                if let result = result {
+                    strongSelf.manager.unpublishL2CAPChannel(result)
+                }
+            }
+        }
+        return observable.ensure(.poweredOn, manager: self)
+    }
+
+    /// Continuous observer for `CBPeripheralManagerDelegate.peripheralManager(_:didOpen:error:)` results
+    /// - returns: Observable that emits `next` event whenever didOpen occurs.
+    ///
+    /// It's **infinite** stream, so `.complete` is never called.
+    ///
+    @available(iOS 11, tvOS 11, watchOS 4, *)
+    public func observeDidOpenL2CAPChannel() -> AnyPublisher<(CBL2CAPChannel?, Error?), Never> {
+        delegateWrapper.didOpenChannel.ensure(.poweredOn, manager: self)
+    }
+    #endif
+
+    // MARK: Internal functions
+
+    func ensureValidStateAndCallIfSucceeded<T, F>(for publisher: AnyPublisher<T, F>,
+                                               postSubscriptionCall call: @escaping () -> Void
+        ) -> AnyPublisher<T, F> {
+        let operation = Deferred<Empty<T, F>> {
+            call()
+            return Empty()
+        }
+        return publisher
+            .merge(with: operation)
+            .ensure(.poweredOn, manager: self)
+    }
+}
+
+private extension Publisher {
+    
+    func ensure(_ state: ManagerState, manager: BLEPeripheralManager) -> AnyPublisher<Self.Output, Self.Failure> {
+        self.prefix(untilOutputFrom: manager.observeStateWithInitialValue().filter { $0 != state }).eraseToAnyPublisher()
+    }
+}

--- a/Source/Peripheral Manager/BLEPeripheralManager.swift
+++ b/Source/Peripheral Manager/BLEPeripheralManager.swift
@@ -399,7 +399,7 @@ public class BLEPeripheralManager {
         ) -> AnyPublisher<T, F> {
         let operation = Deferred<Empty<T, F>> {
             call()
-            return Empty()
+            return Empty(completeImmediately: false)
         }
         return publisher
             .merge(with: operation)

--- a/Source/Peripheral Manager/BLEPeripheralManager.swift
+++ b/Source/Peripheral Manager/BLEPeripheralManager.swift
@@ -158,7 +158,14 @@ public class BLEPeripheralManager {
                         return StartAdvertisingResult.started
                     }
                     .mapError { $0 as! BLEError }
-                    .sink(receiveCompletion: { observer.send(completion: $0) }, receiveValue: { observer.send($0) })
+                    .sink(
+                        receiveCompletion: {
+                            if case .failure = $0 { observer.send(completion: $0) }
+                        },
+                        receiveValue: {
+                            observer.send($0)
+                        }
+                    )
                 strongSelf.manager.startAdvertising(advertisementData)
             }
             return AnyCancellable { [weak self] in
@@ -179,9 +186,9 @@ public class BLEPeripheralManager {
     /// Function that triggers `CBPeripheralManager.add(_:)` and waits for
     /// delegate `CBPeripheralManagerDelegate.peripheralManager(_:didAdd:error:)` result.
     /// If it receives a non nil in the result, it will emit `BLEError.addingServiceFailed` error.
-    /// Add method is called after subscription to `Observable` is made.
+    /// Add method is called after subscription to `AnyPublisher` is made.
     /// - Parameter service: `Characteristic` to read value from
-    /// - Returns: `Single` which emits `next` with given characteristic when value is ready to read.
+    /// - Returns: `AnyPublisher` which emits single `next` with given characteristic when value is ready to read.
     ///
     /// Observable can ends with following errors:
     /// * `BLEError.addingServiceFailed`

--- a/Source/Peripheral Manager/BLEPeripheralManagerDelegateWrapper.swift
+++ b/Source/Peripheral Manager/BLEPeripheralManagerDelegateWrapper.swift
@@ -1,0 +1,92 @@
+//
+//  BLEPeripheralManagerDelegateWrapper.swift
+//  BLECombineKit
+//
+//  Created by Przemyslaw Stasiak on 12/07/2021.
+//  Copyright © 2021 Henry Serrano. All rights reserved.
+//
+
+import Foundation
+import CoreBluetooth
+import Combine
+
+
+/// Based on Polidea/RxBluetoothKit/Source/CBPeripheralManagerDelegateWrapper.swift
+///
+/// See original source on [GitHub](https://github.com/Polidea/RxBluetoothKit/blob/2a95bce60fb569df57d7bec41d215fe58f56e1d4/Source/CBPeripheralManagerDelegateWrapper.swift).
+///
+class BLEPeripheralManagerDelegateWrapper: NSObject, CBPeripheralManagerDelegate {
+
+    let didUpdateState = PassthroughSubject<ManagerState, Never>()
+    let isReady = PassthroughSubject<Void, Never>()
+    let didStartAdvertising = PassthroughSubject<Error?, Never>()
+    let didReceiveRead = PassthroughSubject<CBATTRequest, Never>()
+    let willRestoreState = CurrentValueSubject<[String: Any], Never>(.init())
+    let didAddService = PassthroughSubject<(CBService, Error?), Never>()
+    let didReceiveWrite = PassthroughSubject<[CBATTRequest], Never>()
+    let didSubscribeTo = PassthroughSubject<(CBCentral, CBCharacteristic), Never>()
+    let didUnsubscribeFrom = PassthroughSubject<(CBCentral, CBCharacteristic), Never>()
+    let didPublishL2CAPChannel = PassthroughSubject<(CBL2CAPPSM, Error?), Never>()
+    let didUnpublishL2CAPChannel = PassthroughSubject<(CBL2CAPPSM, Error?), Never>()
+    private var _didOpenChannel: Any?
+    @available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)
+    var didOpenChannel: PassthroughSubject<(CBL2CAPChannel?, Error?), Never> {
+        if _didOpenChannel == nil {
+            _didOpenChannel = PassthroughSubject<(CBL2CAPChannel?, Error?), Never>()
+        }
+        return _didOpenChannel as! PassthroughSubject<(CBL2CAPChannel?, Error?), Never>
+    }
+
+    func peripheralManagerDidUpdateState(_ peripheral: CBPeripheralManager) {
+        guard let bleState = ManagerState(rawValue: peripheral.state.rawValue) else { return }
+        didUpdateState.send(bleState)
+    }
+
+    func peripheralManagerIsReady(toUpdateSubscribers peripheral: CBPeripheralManager) {
+        isReady.send()
+    }
+
+    func peripheralManagerDidStartAdvertising(_ peripheral: CBPeripheralManager, error: Error?) {
+        didStartAdvertising.send(error)
+    }
+
+    func peripheralManager(_ peripheral: CBPeripheralManager, didReceiveRead request: CBATTRequest) {
+        didReceiveRead.send(request)
+    }
+
+    func peripheralManager(_ peripheral: CBPeripheralManager, willRestoreState dict: [String: Any]) {
+        willRestoreState.send(dict)
+    }
+
+    func peripheralManager(_ peripheral: CBPeripheralManager, didAdd service: CBService, error: Error?) {
+        didAddService.send((service, error))
+    }
+
+    func peripheralManager(_ peripheral: CBPeripheralManager, didReceiveWrite requests: [CBATTRequest]) {
+        didReceiveWrite.send(requests)
+    }
+
+    func peripheralManager(_ peripheral: CBPeripheralManager, central: CBCentral,
+                           didSubscribeTo characteristic: CBCharacteristic) {
+        didSubscribeTo.send((central, characteristic))
+    }
+
+    func peripheralManager(_ peripheral: CBPeripheralManager,
+                           central: CBCentral,
+                           didUnsubscribeFrom characteristic: CBCharacteristic) {
+        didUnsubscribeFrom.send((central, characteristic))
+    }
+
+    func peripheralManager(_ peripheral: CBPeripheralManager, didPublishL2CAPChannel PSM: CBL2CAPPSM, error: Error?) {
+        didPublishL2CAPChannel.send((PSM, error))
+    }
+
+    func peripheralManager(_ peripheral: CBPeripheralManager, didUnpublishL2CAPChannel PSM: CBL2CAPPSM, error: Error?) {
+        didUnpublishL2CAPChannel.send((PSM, error))
+    }
+
+    @available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)
+    func peripheralManager(_ peripheral: CBPeripheralManager, didOpen channel: CBL2CAPChannel?, error: Error?) {
+        didOpenChannel.send((channel, error))
+    }
+}

--- a/Source/Peripheral Manager/StartAdvertisingResult.swift
+++ b/Source/Peripheral Manager/StartAdvertisingResult.swift
@@ -1,0 +1,33 @@
+//
+//  StartAdvertisingResult.swift
+//  BLECombineKit
+//
+//  Created by Przemyslaw Stasiak on 12/07/2021.
+//  Copyright © 2021 Henry Serrano. All rights reserved.
+//
+
+import Foundation
+
+/// Based on Polidea/RxBluetoothKit/Source/StartAdvertisingResult.swift
+///
+/// See original source on [GitHub](https://github.com/Polidea/RxBluetoothKit/blob/2a95bce60fb569df57d7bec41d215fe58f56e1d4/Source/StartAdvertisingResult.swift).
+///
+
+public typealias RestoredAdvertisementData = [String: Any]
+
+/// Enum result that is returned as a result of `PeripheralManager.startAdvertising` method
+public enum StartAdvertisingResult {
+    /// Advertising started properly with specified `advertisementData`
+    case started
+    /// This is a special case meaning that there is already ongoing advertising that has been started
+    /// outside of `RxBluetoothKit` library and `PeripherlManager.startAdvertising` did only attached
+    /// to ongoing advertising without calling `CBPeripheralManager.startAdvertising`.
+    /// The reason behind that is that we want to give user possibility to stop advertising in
+    /// such state.
+    /// In most cases it happens when app went from background with ongoing advertising - in that case you will receive `RestoredAdvertisementData` param, so you can know with what `advertisementData` it was started before app went background.
+    /// WARNING: remember that this is not really calling `CBPeripheralManager.startAdvertising`
+    /// so it might be not started with `advertisementData` param that you've provided. If you
+    /// want to start with different `advertisementData` then you will need to dispose
+    /// advertising observable and call `startAdvertising` again.
+    case attachedToExternalAdvertising(RestoredAdvertisementData?)
+}


### PR DESCRIPTION
- Combine-based APIs for creating BLE peripheral.
- Added [CombineExt](https://github.com/CombineCommunity/CombineExt) dependency.
- Based on [RxBluetoothKit](https://github.com/Polidea/RxBluetoothKit).