### PR TITLE
Bugfix - disconnecting peripheral

### DIFF
--- a/BLECombineKit.xcodeproj/project.pbxproj
+++ b/BLECombineKit.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -52,6 +52,7 @@
 		39E7B702245ED60B0065044C /* DevicesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E7B701245ED60B0065044C /* DevicesView.swift */; };
 		39E7B705245ED6840065044C /* ActionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E7B704245ED6840065044C /* ActionState.swift */; };
 		39E7B708245EDA320065044C /* BLECombineKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E7B707245EDA320065044C /* BLECombineKit.swift */; };
+		486C7B6226E90D3F0061CC52 /* CombineExt in Frameworks */ = {isa = PBXBuildFile; productRef = 486C7B6126E90D3F0061CC52 /* CombineExt */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -145,6 +146,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				486C7B6226E90D3F0061CC52 /* CombineExt in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -412,6 +414,9 @@
 			dependencies = (
 			);
 			name = BLECombineKit;
+			packageProductDependencies = (
+				486C7B6126E90D3F0061CC52 /* CombineExt */,
+			);
 			productName = BLECombineKit;
 			productReference = 39AC63C4245D07A70024D677 /* BLECombineKit.framework */;
 			productType = "com.apple.product-type.framework";
@@ -484,6 +489,9 @@
 				Base,
 			);
 			mainGroup = 39AC63BA245D07A70024D677;
+			packageReferences = (
+				486C7B6026E90D3F0061CC52 /* XCRemoteSwiftPackageReference "CombineExt" */,
+			);
 			productRefGroup = 39AC63C5245D07A70024D677 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -907,6 +915,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		486C7B6026E90D3F0061CC52 /* XCRemoteSwiftPackageReference "CombineExt" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/CombineCommunity/CombineExt.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.3.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		486C7B6126E90D3F0061CC52 /* CombineExt */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 486C7B6026E90D3F0061CC52 /* XCRemoteSwiftPackageReference "CombineExt" */;
+			productName = CombineExt;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 39AC63BB245D07A70024D677 /* Project object */;
 }

--- a/BLECombineKit.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/BLECombineKit.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:BLECombineKit.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/BLECombineKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BLECombineKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,34 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "combine-schedulers",
+        "repositoryURL": "https://github.com/pointfreeco/combine-schedulers",
+        "state": {
+          "branch": null,
+          "revision": "c37e5ae8012fb654af776cc556ff8ae64398c841",
+          "version": "0.5.0"
+        }
+      },
+      {
+        "package": "CombineExt",
+        "repositoryURL": "https://github.com/CombineCommunity/CombineExt.git",
+        "state": {
+          "branch": null,
+          "revision": "5b8a0c0f178527f9204200505c5fefa6847e528f",
+          "version": "1.3.0"
+        }
+      },
+      {
+        "package": "xctest-dynamic-overlay",
+        "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
+        "state": {
+          "branch": null,
+          "revision": "603974e3909ad4b48ba04aad7e0ceee4f077a518",
+          "version": "0.1.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -11,11 +11,16 @@ let package = Package(
     products: [
         .library(name: "BLECombineKit", targets: ["BLECombineKit"])
     ],
-    dependencies: [],
+    dependencies: [
+        .package(
+            url: "https://github.com/CombineCommunity/CombineExt.git",
+            from: "1.0.0"
+        )
+    ],
     targets: [
         .target(
                 name: "BLECombineKit",
-                dependencies: [],
+                dependencies: ["CombineExt"],
                 path: ".",
                 exclude: [
                     "Source/BLECombineKit.h",

--- a/Source/Central/BLECentralManager.swift
+++ b/Source/Central/BLECentralManager.swift
@@ -9,6 +9,7 @@
 import Foundation
 import CoreBluetooth
 import Combine
+import CombineExt
 
 public protocol BLECentralManager: AnyObject {
     var centralManager: CBCentralManagerWrapper { get }

--- a/Source/Central/BLECentralManager.swift
+++ b/Source/Central/BLECentralManager.swift
@@ -19,7 +19,7 @@ public protocol BLECentralManager: AnyObject {
     func scanForPeripherals(withServices services: [CBUUID]?, options: [String: Any]?) -> AnyPublisher<BLEScanResult, BLEError>
     func stopScan()
     func connect(peripheralWrapper: CBPeripheralWrapper, options: [String:Any]?)
-    func cancelPeripheralConnection(_ peripheral: CBPeripheralWrapper) -> AnyPublisher<Bool, BLEError>
+    func cancelPeripheralConnection(_ peripheral: CBPeripheralWrapper) -> AnyPublisher<Never, Never>
     func registerForConnectionEvents(options: [CBConnectionEventMatchingOption : Any]?)
     func observeWillRestoreState() -> AnyPublisher<[String: Any], Never>
     func observeDidUpdateANCSAuthorization() -> AnyPublisher<BLEPeripheral, Never>
@@ -136,13 +136,14 @@ final class StandardBLECentralManager: BLECentralManager {
         centralManager.connect(peripheralWrapper, options: options)
     }
     
-    public func cancelPeripheralConnection(_ peripheral: CBPeripheralWrapper) -> AnyPublisher<Bool, BLEError> {
+    public func cancelPeripheralConnection(_ peripheral: CBPeripheralWrapper) -> AnyPublisher<Never, Never> {
         centralManager.cancelPeripheralConnection(peripheral)
         
         return delegate.didDisconnectPeripheral
             .filter { $0.identifier == peripheral.identifier }
-            .map { _ in true }
-            .setFailureType(to: BLEError.self)
+            .first()
+            .ignoreOutput()
+            .ignoreFailure()
             .eraseToAnyPublisher()
     }
     

--- a/Source/Peripheral/BLEPeripheral.swift
+++ b/Source/Peripheral/BLEPeripheral.swift
@@ -15,7 +15,7 @@ public protocol BLEPeripheral {
 
     func observeConnectionState() -> AnyPublisher<Bool, Never>
     func connect(with options: [String: Any]?) -> AnyPublisher<BLEPeripheral, BLEError>
-    @discardableResult func disconnect() -> AnyPublisher<Bool, BLEError>
+    @discardableResult func disconnect() -> AnyPublisher<Never, BLEError>
     func observeRSSIValue() -> AnyPublisher<NSNumber, BLEError>
     func discoverServices(serviceUUIDs: [CBUUID]?) -> AnyPublisher<BLEService, BLEError>
     func discoverCharacteristics(characteristicUUIDs: [CBUUID]?, for service: CBService) -> AnyPublisher<BLECharacteristic, BLEError>

--- a/Source/Peripheral/StandardBLEPeripheral.swift
+++ b/Source/Peripheral/StandardBLEPeripheral.swift
@@ -67,14 +67,17 @@ final public class StandardBLEPeripheral: BLEPeripheral, BLEPeripheralState {
     }
     
     @discardableResult
-    public func disconnect() -> AnyPublisher<Bool, BLEError> {
+    public func disconnect() -> AnyPublisher<Never, BLEError> {
         guard let centralManager = centralManager else {
             return Just.init(false)
                 .tryMap { _ in throw BLEError.disconnectionFailed }
                 .mapError { $0 as? BLEError ?? BLEError.unknown }
                 .eraseToAnyPublisher()
         }
-        return centralManager.cancelPeripheralConnection(peripheral)
+        return centralManager
+            .cancelPeripheralConnection(peripheral)
+            .setFailureType(to: BLEError.self)
+            .eraseToAnyPublisher()
     }
     
     public func observeRSSIValue() -> AnyPublisher<NSNumber, BLEError> {

--- a/Tests/Mocks/BLEPeripheralMocks.swift
+++ b/Tests/Mocks/BLEPeripheralMocks.swift
@@ -12,7 +12,7 @@ import Combine
 @testable import BLECombineKit
 
 final class MockBLEPeripheral: BLEPeripheral, BLEPeripheralState {
-    
+
     let connectionState = CurrentValueSubject<Bool, Never>(false)
     var peripheral: CBPeripheralWrapper
     
@@ -34,9 +34,9 @@ final class MockBLEPeripheral: BLEPeripheral, BLEPeripheralState {
     }
     
     var disconnectWasCalled = false
-    func disconnect() -> AnyPublisher<Bool, BLEError> {
+    func disconnect() -> AnyPublisher<Never, BLEError> {
         disconnectWasCalled = true
-        return Just.init(false).setFailureType(to: BLEError.self).eraseToAnyPublisher()
+        return Empty(completeImmediately: true).eraseToAnyPublisher()
     }
     
     var discoverServiceWasCalled = false

--- a/Tests/Mocks/MockBLECentralManager.swift
+++ b/Tests/Mocks/MockBLECentralManager.swift
@@ -62,10 +62,10 @@ final class MockBLECentralManager: BLECentralManager {
     }
     
     var cancelPeripheralConnectionWasCalledCount = 0
-    func cancelPeripheralConnection(_ peripheral: CBPeripheralWrapper) -> AnyPublisher<Bool, BLEError> {
+    func cancelPeripheralConnection(_ peripheral: CBPeripheralWrapper) -> AnyPublisher<Never, Never> {
         cancelPeripheralConnectionWasCalledCount += 1
         
-        return Just.init(false).setFailureType(to: BLEError.self).eraseToAnyPublisher()
+        return Empty(completeImmediately: true).eraseToAnyPublisher()
     }
     
     var registerForConnectionEventsWasCalledCount = 0


### PR DESCRIPTION
Publisher returned by `cancelPeripheralConnection` completes after disconnecting.